### PR TITLE
Fix flat triangle color

### DIFF
--- a/highcharts-contour.js
+++ b/highcharts-contour.js
@@ -134,7 +134,7 @@ seriesTypes.contour = extendClass(seriesTypes.heatmap, {
 
 		//All vertexes have the same value/color
 		if (Math.abs(values[0] - values[1]) < eps && Math.abs(values[0] - values[2]) < eps) {
-			fill = this.colorAxis.toColor((values[0]+values[1]+values[2])/3);
+			fill = this.colorAxis.toColor((a[colorKey] + b[colorKey] + c[colorKey]) / 3);
 		//Use a linear gradient to interpolate values/colors
 		} else {
 			//Find function where "Value = A*X + B*Y + C" at the 3 vertexes


### PR DESCRIPTION
Fixes bug in 3D contour triangle drawing. For the case of flat triangles, it was passing in relative values to the color calculation which expects absolute, causing them to be the minimum stop color