### PR TITLE
Ignore points with null value

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "contour",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "title": "Contour Curves",
     "author": {
         "name": "Paulo Costa",


### PR DESCRIPTION
This fixes issue #1

When `grid_width` is specified, a hole will be left on the mesh.
When Delaunay is used, the broken vertex will not be part of the triangulation