### PR TITLE
Plugin made compatible with the older browsers.

### DIFF
--- a/highcharts-contour.js
+++ b/highcharts-contour.js
@@ -51,6 +51,30 @@ wrap(Highcharts.ColorAxis.prototype, 'setAxisSize', function (proceed) {
 
 Highcharts.Axis.prototype.drawCrosshair = function() {};
 
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function (oThis) {
+    if (typeof this !== "function") {
+      // closest thing possible to the ECMAScript 5 internal IsCallable function
+      throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+    }
+
+    var aArgs = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP = function () {},
+        fBound = function () {
+          return fToBind.apply(this instanceof fNOP && oThis
+                                 ? this
+                                 : oThis,
+                               aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}
+
 // The Heatmap series type
 seriesTypes.contour = extendClass(seriesTypes.heatmap, {
     type: 'contour',


### PR DESCRIPTION
In my case the plugin was not compatible with Safari 5.1 WebKit 534 on OSX. Frunctions.prototype.bind was missing. I do not know the reason, because this function should be in this version of browser. 
I added small peace of code which implements this functionality. https://www.smashingmagazine.com/2014/01/understanding-javascript-function-prototype-bind/

Maybe position of function in file is not correct. Feel free to suggest other position. 
